### PR TITLE
use AB::MB for configure_requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -109,7 +109,7 @@ my $builder = Alien::Base::ModuleBuild->new (
     dynamic_config => 1,
     license => 'perl',
     configure_requires => {
-	'Alien::Base' => '0.002',
+	'Alien::Base::ModuleBuild' => '0.002',
 	'Module::Build' => '0.38'
     },
     requires => {


### PR DESCRIPTION
For rationale, please see https://github.com/Perl5-Alien/Alien-Base/issues/157